### PR TITLE
Splitting Data While Posting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,7 +76,7 @@ web_modules/
 .yarn-integrity
 
 # dotenv environment variable files
-.env
+*.env*
 .env.development.local
 .env.test.local
 .env.production.local

--- a/Documentation/Redis/DataTyps.md
+++ b/Documentation/Redis/DataTyps.md
@@ -1,0 +1,87 @@
+# How do I store data in Redis for my use case ?
+
+To store complex JSON objects in Redis while maintaining parent-child relationships, you can use hashes for objects and sets or lists for arrays. Redis doesn't directly support nested objects, so you need to flatten the structure and establish relationships using keys.
+
+Refer [Sample JSON](../../schemas/Data.Schema.json) for seeing how the object looks. 
+
+Here's a step-by-step guide on how to achieve this, referencing the provided JSON object and the Redis keys from your image:
+
+1. **Identify Top-Level Object**:
+   Your JSON has a top-level object that represents a "plan" with an `objectId`.
+
+2. **Use Hashes for Objects**:
+   Store each JSON object in a Redis hash, with the object's `objectId` as part of the key for easy retrieval and association. For instance:
+
+   ```
+   HSET plan:12xvxc345ssdsds-508 field1 value1 field2 value2 ...
+   ```
+
+   Here, `field1`, `field2`, etc., represent the keys within the JSON object, and `value1`, `value2`, etc., are their corresponding values.
+
+3. **Linking Child Objects**:
+   For each linked object, store it in a separate hash using its `objectId`:
+
+   ```
+   HSET planservice:27283xvx9asdff-504 field1 value1 field2 value2 ...
+   ```
+
+4. **Storing Arrays**:
+   Arrays, such as `linkedPlanServices`, can be represented as Redis lists or sets. Since the order is not specified as important, you could use a set for this example. Add the `objectId` of each "planservice" to the set:
+
+   ```
+   SADD plan:12xvxc345ssdsds-508:linkedPlanServices 27283xvx9asdff-504 27283xvx9sdf-507
+   ```
+
+5. **Storing Nested Objects within Arrays**:
+   Each `linkedService` and `planserviceCostShares` is stored as a separate hash, similar to the top-level plan object:
+
+   ```
+   HSET service:1234520xvc30asdf-502 field1 value1 ...
+   HSET membercostshare:1234512xvc1314asdfs-503 field1 value1 ...
+   ```
+
+6. **Referencing Parent in Child Objects**:
+   In each child object, include a reference back to the parent object. You can store this in the hash or as a separate key-value pair:
+
+   ```
+   HSET planservice:27283xvx9asdff-504 parent 12xvxc345ssdsds-508
+   ```
+
+7. **Node.js Integration**:
+   In your Node.js application, you will parse the JSON object and generate these Redis commands to store the data appropriately. Here’s a very simplified pseudocode snippet on how to do this:
+
+    ```javascript
+    const redis = require('redis');
+    const client = redis.createClient();
+
+    // Function to store a plan object
+    function storePlan(planObject) {
+    const planId = `plan:${planObject.objectId}`;
+    client.hset(planId, 'planType', planObject.planType, 'creationDate', planObject.creationDate);
+    
+    // Store the main plan cost shares
+    const planCostSharesId = `membercostshare:${planObject.planCostShares.objectId}`;
+    client.hset(planCostSharesId, ...Object.entries(planObject.planCostShares));
+    
+    // Store linked plan services
+    planObject.linkedPlanServices.forEach(service => {
+        const planserviceId = `planservice:${service.objectId}`;
+        client.sadd(`${planId}:linkedPlanServices`, service.objectId);
+        client.hset(planserviceId, ...Object.entries(service));
+
+        // Store nested objects like linkedService and planserviceCostShares
+        const linkedServiceId = `service:${service.linkedService.objectId}`;
+        client.hset(linkedServiceId, ...Object.entries(service.linkedService));
+
+        const serviceCostSharesId = `membercostshare:${service.planserviceCostShares.objectId}`;
+        client.hset(serviceCostSharesId, ...Object.entries(service.planserviceCostShares));
+    });
+    }
+
+    // Usage
+    storePlan(yourJsonPlanObject);
+    ```
+
+    **Note**: The `...Object.entries(object)` part is pseudocode for the purpose of illustration. You would need to properly iterate over each property of your objects and use `hset` correctly for each field-value pair.
+
+By following these steps, you should be able to take the JSON object provided to your Node.js API, parse it, and store it in Redis in a structured way that preserves the relationships between objects.

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "integration": "NODE_ENV=integration npx jest --detectOpenHandles --forceExit --runInBand --testMatch=\"**/integration/**\"",
     "test": "npx jest --coverage",
-    "dev": "nodemon --exec npx esrun src/index.ts",
+    "dev": "NODE_ENV=development nodemon --exec npx esrun src/index.ts",
     "debugDev": "npx esrun src/index.ts",
     "clean-up": "rm -rf dist && rm -rf ./src/routes",
     "generate-tsoa": "tsoa spec-and-routes",

--- a/schemas/Data.Schema.json
+++ b/schemas/Data.Schema.json
@@ -1,55 +1,55 @@
 {
+  "planCostShares": {
+    "deductible": 2000,
+    "_org": "example.com",
+    "copay": 23,
+    "objectId": "1234vxc2324sdf-501",
+    "objectType": "membercostshare"
+  },
+  "linkedPlanServices": [
+    {
+      "linkedService": {
+        "_org": "example.com",
+        "objectId": "1234520xvc30asdf-502",
+        "objectType": "service",
+        "name": "Yearly physical"
+      },
+      "planserviceCostShares": {
+        "deductible": 10,
+        "_org": "example.com",
+        "copay": 0,
+        "objectId": "1234512xvc1314asdfs-503",
+        "objectType": "membercostshare"
+      },
+      "_org": "example.com",
+      "objectId": "27283xvx9asdff-504",
+      "objectType": "planservice"
+    },
+    {
+      "linkedService": {
+        "_org": "example.com",
+        "objectId": "1234520xvc30sfs-505",
+        "objectType": "service",
+        "name": "well baby"
+      },
+      "planserviceCostShares": {
+        "deductible": 10,
+        "_org": "example.com",
+        "copay": 175,
+        "objectId": "1234512xvc1314sdfsd-506",
+        "objectType": "membercostshare"
+      },
 
-	"planCostShares": {
-		"deductible": 2000,
-		"_org": "example.com",
-		"copay": 23,
-		"objectId": "1234vxc2324sdf-501",
-		"objectType": "membercostshare"
+      "_org": "example.com",
 
-	},
-	"linkedPlanServices": [{
-		"linkedService": {
-			"_org": "example.com",
-			"objectId": "1234520xvc30asdf-502",
-			"objectType": "service",
-			"name": "Yearly physical"
-		},
-		"planserviceCostShares": {
-			"deductible": 10,
-			"_org": "example.com",
-			"copay": 0,
-			"objectId": "1234512xvc1314asdfs-503",
-			"objectType": "membercostshare"
-		},
-		"_org": "example.com",
-		"objectId": "27283xvx9asdff-504",
-		"objectType": "planservice"
-	}, {
-		"linkedService": {
-			"_org": "example.com",
-			"objectId": "1234520xvc30sfs-505",
-			"objectType": "service",
-			"name": "well baby"
-		},
-		"planserviceCostShares": {
-			"deductible": 10,
-			"_org": "example.com",
-			"copay": 175,
-			"objectId": "1234512xvc1314sdfsd-506",
-			"objectType": "membercostshare"
-		},
+      "objectId": "27283xvx9sdf-507",
+      "objectType": "planservice"
+    }
+  ],
 
-		"_org": "example.com",
-
-		"objectId": "27283xvx9sdf-507",
-		"objectType": "planservice"
-	}],
-
-
-	"_org": "example.com",
-	"objectId": "12xvxc345ssdsds-508",
-	"objectType": "plan",
-	"planType": "inNetwork",
-	"creationDate": "12-12-2017"
+  "_org": "example.com",
+  "objectId": "12xvxc345ssdsds-508",
+  "objectType": "plan",
+  "planType": "inNetwork",
+  "creationDate": "12-12-2017"
 }


### PR DESCRIPTION
## Implement JSON Object Storage in Redis Preserving Relationships

### Description
This PR introduces a new method to parse and store complex JSON objects in Redis. The implementation ensures that parent-child relationships within the JSON objects are maintained by using Redis hashes, sets, and additional key references.
- Flattened JSON objects and stored each field in Redis hashes with the object's `objectId` included in the key for association.
- Created Redis sets to represent arrays from the JSON object, storing `objectId`s of child objects.
- Ensured backward referencing by including the parent `objectId` in each child object.
- Utilized transactional commands to ensure the atomicity of Redis operations where necessary.
- Wrapped the storage logic in a Node.js API endpoint to facilitate JSON object handling via HTTP requests.

### Modules changed
- `src/utils/redis.util.ts`: Contains the core functionality for processing and storing JSON objects in Redis.

### Screenshots

We now see that we have each element split when stored in Redis
<img width="1015" alt="Screenshot 2024-04-11 at 2 55 11 PM" src="https://github.com/Advanced-bigData-and-indexing/webapp/assets/113069126/1653108b-98ea-43d0-b996-8c5be00827a1">
